### PR TITLE
Bootstrap functional model surface standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
-# functional-model-surfaces
-Functional foundation model surface standards for SocioProphet: model, adapter, dataset, eval, guardrail, tool, agent, routing, promotion, and SourceOS carry contracts.
+# Functional Model Surfaces
+
+Functional Model Surfaces is the normative standards home for SocioProphet functional AI capability surfaces.
+
+This repository defines the cross-plane contracts for reusable capability families such as speech/audio, OCR/document vision, image/vision, video/temporal media, translation/multilingual, embeddings/retrieval, guardrails, tools, agents, routing, evaluation, promotion, and SourceOS carry references.
+
+## Doctrine
+
+Domains consume functional surfaces. Domains do not own foundation capability surfaces.
+
+SocioProphet owns platform service contracts, catalog entries, runtime bindings, evaluation gates, evidence records, routing policy, and signed promotion state.
+
+SociOS Linux owns local lab execution, training/tuning experiments, workstation runtime integration, accelerator integration, datasets, and candidate artifacts.
+
+SourceOS carries service clients, launch profiles, pinned service references, ReleaseSet/BootReleaseSet wiring, cache policy, and evidence collectors. SourceOS does not carry mutable model-update authority.
+
+## Initial surfaces
+
+- speech/audio
+- OCR/document vision
+- image/vision
+- video/temporal media
+- translation/multilingual
+- embeddings/retrieval/rerank
+- safety/guardrails
+- agent/tool orchestration
+
+## Initial repo mapping
+
+- `SocioProphet/prophet-platform`: runtime service implementation and platform records
+- `SociOS-Linux/speechlab`: speech/audio lab execution
+- `SociOS-Linux/ocrlab`: OCR/document vision lab execution
+- `SociOS-Linux/imagelab`: image/vision lab execution
+- `SociOS-Linux/videolab`: video/temporal media lab execution
+- `SociOS-Linux/translationlab`: planned translation/multilingual lab execution
+- `SociOS-Linux/embeddinglab`: planned embeddings/retrieval lab execution
+- `SourceOS-Linux/sourceos-spec`: SourceOS carry references and conformance
+
+## Reading order
+
+1. `docs/ARCHITECTURE.md`
+2. `docs/OWNERSHIP.md`
+3. `contracts/README.md`
+4. `examples/README.md`
+5. `tools/README.md`
+
+## Current phase
+
+This repository is being bootstrapped as a standards spine. Runtime service code belongs in `SocioProphet/prophet-platform` after contracts are validated.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,118 @@
+# Functional Model Surfaces Architecture
+
+## Core thesis
+
+Functional model surfaces are reusable capability families. They are not domain repositories and they are not application-specific feature folders.
+
+A functional surface is the stable contract around a capability such as speech, OCR, image, video, translation, embeddings, rerank, guardrails, tools, or agents. Domains bind to those surfaces through adapters, datasets, policies, eval gates, and promotion records.
+
+## Layer model
+
+1. Functional foundation surface
+2. Task adapter
+3. Domain adapter
+4. Organization, project, or user policy
+5. Eval gate
+6. Signed promotion
+7. Runtime deployment
+8. SourceOS carry reference
+
+## Object graph
+
+```text
+FunctionalModelSurface
+  -> FoundationModelRef
+  -> TaskAdapter
+  -> DomainAdapter
+  -> DatasetArtifact
+  -> TrainingRun
+  -> ModelArtifact
+  -> AdapterArtifact
+  -> EvalRun
+  -> GuardrailPolicy
+  -> ToolContract
+  -> KnowledgeBaseRef
+  -> AgentSpec
+  -> AgentIdentity
+  -> RuntimeDeployment
+  -> ModelRouterPolicy
+  -> PromotionRecord
+  -> SourceOSCarryRef
+```
+
+## Authority split
+
+### SocioProphet
+
+SocioProphet owns governed platform capability:
+
+- standards and contracts;
+- service catalog entries;
+- runtime service manifests;
+- TriTRPC and gateway bindings;
+- evaluation gates;
+- evidence and promotion records;
+- guardrail and routing policy;
+- model, adapter, dataset, tool, knowledge-base, and agent registries.
+
+### SociOS Linux
+
+SociOS Linux owns local lab execution:
+
+- training and tuning experiments;
+- datasets and local corpora;
+- model and adapter candidates;
+- workstation and accelerator integration;
+- reproducible lab shells;
+- local smoke tests and eval fixtures.
+
+### SourceOS
+
+SourceOS owns secure carriage and launch:
+
+- clients;
+- launch profiles;
+- signed service references;
+- ReleaseSet and BootReleaseSet wiring;
+- cache policy;
+- evidence collectors;
+- offline-safe fallback references.
+
+SourceOS must not become the authority for mutable model updates.
+
+## Promotion chain
+
+```text
+lab experiment
+  -> dataset evidence
+  -> training or tuning evidence
+  -> artifact digest
+  -> eval gate
+  -> guardrail policy
+  -> deployment mode
+  -> routing policy
+  -> signed promotion
+  -> SourceOS carry reference
+```
+
+## Runtime binding
+
+Internal platform services should be TriTRPC-first. HTTP gateway routes may exist for browser and external access, but the normative internal service contract should remain typed, signed, and evidence-aware.
+
+Recommended method families:
+
+- `modality.speech.v1/*`
+- `modality.ocr.v1/*`
+- `modality.image.v1/*`
+- `modality.video.v1/*`
+- `modality.translation.v1/*`
+- `modality.embedding.v1/*`
+- `guardrail.fabric.v1/*`
+- `model.router.v1/*`
+- `agent.registry.v1/*`
+
+## Non-goals
+
+This repository does not store model binaries, mutable model update channels, domain datasets, or runtime service implementations.
+
+Runtime implementation belongs in `SocioProphet/prophet-platform` or in explicitly designated service repos. Lab execution belongs in SociOS Linux lab repos. SourceOS carriage contracts belong in SourceOS standards and carry surfaces.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -14,11 +14,45 @@ The default user path is one suite command surface:
 brew tap SocioProphet/prophet
 brew install prophet-cli
 prophet doctor
+prophet devtools doctor
+prophet devtools profile apply ai-core
 prophet sourceos carry list
 prophet holmes analyze ./document.txt
 ```
 
 Specialized tools may also be installed directly, but every direct tool must have an equivalent `prophet <surface>` path.
+
+## SourceOS Developer Tools
+
+`sourceos-devtools` is the Linux/AI-native developer tools layer for SourceOS and SocioProphet.
+
+It is analogous in product role to Apple developer tooling, but it is built for local-first AI governance, lab profile selection, release engineering, model/service lifecycle control, and SourceOS workstation workflows.
+
+It must install a toolchain manager and profile resolver. It must not blindly install every heavy lab dependency, dataset, or model artifact.
+
+Initial profile families:
+
+- `sourceos-devtools-core`: git, gh, make, jq/yq, direnv, shell integration, evidence tooling.
+- `sourceos-devtools-build`: Go/Rust/Python/Node build support, release tooling, checksums, SBOM, attestations.
+- `sourceos-devtools-containers`: podman/buildah, Docker-compatible hooks, devcontainers, local registry support.
+- `sourceos-devtools-k8s`: kubectl, helm, kustomize, kind/k3d, local cluster hooks.
+- `sourceos-devtools-ai-core`: prophet, sourceos-ai, holmes, model-router, guardrail-fabric, agent-registry.
+- `sourceos-devtools-labs`: nlplab, translationlab, embeddinglab, speechlab, ocrlab, imagelab, videolab, timeserieslab, graphlab.
+- `sourceos-devtools-security`: cosign, SBOM/scanning tools, secret handling, provenance, policy checks.
+
+The user should be able to select only the profiles needed:
+
+```bash
+prophet devtools profile list
+prophet devtools profile apply core,ai-core,containers
+prophet lab enable image video embedding nlplab
+```
+
+SourceOS installer should also accept devtools profile selection:
+
+```bash
+prophet sourceos install --target m2 --channel dev --devtools core,ai-core,containers --labs image,video,embedding,nlplab
+```
 
 ## Artifact policy
 
@@ -45,6 +79,7 @@ brew tap SocioProphet/prophet
 Initial formulae:
 
 - `prophet-cli`: installs the `prophet` façade command.
+- `sourceos-devtools`: installs the SourceOS developer tools profile manager and lab launcher.
 - `sourceos-ai`: SourceOS AI carry client and local service launcher.
 - `sourceos-installer`: SourceOS installer and BootReleaseSet orchestration launcher.
 - `holmes`: Holmes language intelligence CLI and local service controller.
@@ -99,6 +134,11 @@ Every installable tool must implement:
 ```bash
 prophet doctor
 prophet version
+prophet devtools doctor
+prophet devtools profile list
+prophet devtools profile apply ai-core
+prophet lab list
+prophet lab enable image video embedding nlplab
 prophet sourceos install
 prophet sourceos carry list
 prophet sourceos carry validate
@@ -162,4 +202,5 @@ A product surface is not release-ready until:
 7. `brew install` works on Apple Silicon;
 8. `--version`, `doctor`, `self-test`, and `emit-evidence` commands work;
 9. it emits enough local evidence to identify version, build source, platform, policy, and service references;
-10. it has a rollback or previous-version recovery path when it modifies device state.
+10. it has a rollback or previous-version recovery path when it modifies device state;
+11. devtools and lab profile selection are recorded as evidence when installed through SourceOS or Prophet CLI.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -4,49 +4,55 @@
 
 Functional model surfaces must be installable products, not only source repositories.
 
-Every product-facing surface should produce a versioned command-line or service binary, publish release artifacts, and expose a Homebrew-installable formula through the SocioProphet tap.
+Every product-facing surface must produce a versioned command-line or service binary, publish release artifacts, expose a Homebrew-installable formula, and emit local evidence proving what was installed and what service references it can invoke.
+
+## Golden path
+
+The default user path is one suite command surface:
+
+```bash
+brew tap SocioProphet/prophet
+brew install prophet-cli
+prophet doctor
+prophet sourceos carry list
+prophet holmes analyze ./document.txt
+```
+
+Specialized tools may also be installed directly, but every direct tool must have an equivalent `prophet <surface>` path.
 
 ## Artifact policy
 
 Do not commit compiled binaries into the repository as long-lived `build/` contents.
 
-Build outputs should be produced by CI and attached to GitHub Releases or release artifact storage. Repositories may contain fixtures, examples, and generated manifests, but product binaries should be release artifacts.
+Build outputs must be produced by CI and attached to GitHub Releases or release artifact storage. Repositories may contain fixtures, examples, and generated manifests, but product binaries are release artifacts.
 
-## Install surfaces
+## Tap repository
 
-The public install target should be a Homebrew tap:
-
-```bash
-brew tap SocioProphet/prophet
-brew install holmes
-brew install sourceos-ai
-brew install prophet-cli
-```
-
-The initial tap repository should be:
+The public install target is a Homebrew tap:
 
 ```text
 SocioProphet/homebrew-prophet
 ```
 
-This provides the short tap name:
+This gives the short tap name:
 
-```text
-SocioProphet/prophet
+```bash
+brew tap SocioProphet/prophet
 ```
 
-## Product formulae
+## Core formulae
 
-Initial formulae should include:
+Initial formulae:
 
-- `holmes`: Holmes language intelligence CLI and local service controller.
+- `prophet-cli`: installs the `prophet` façade command.
 - `sourceos-ai`: SourceOS AI carry client and local service launcher.
-- `prophet-cli`: Prophet platform operator CLI.
+- `sourceos-installer`: SourceOS installer and BootReleaseSet orchestration launcher.
+- `holmes`: Holmes language intelligence CLI and local service controller.
 - `model-router`: model/service routing client and policy simulator.
 - `guardrail-fabric`: guardrail test and local policy evaluation CLI.
 - `agent-registry`: agent spec and identity registry client.
 
-Lab formulae should be lightweight. They should install scaffolding and reproducible environment launchers, not large unmanaged model artifacts.
+Lab formulae are lightweight launchers. They install scaffolding and reproducible environment launchers, not large unmanaged model artifacts:
 
 - `nlplab`
 - `translationlab`
@@ -56,14 +62,18 @@ Lab formulae should be lightweight. They should install scaffolding and reproduc
 
 ## Binary strategy
 
-Each product repo should provide:
+Each product repo must provide:
 
-- `cmd/<name>/` or equivalent CLI entrypoint;
+- CLI or service entrypoint;
 - `Makefile` target `build`;
 - `Makefile` target `test`;
+- `Makefile` target `validate`;
 - `Makefile` target `dist`;
+- `Makefile` target `release-dry-run`;
 - GitHub Actions release workflow;
 - release checksum generation;
+- SBOM generation;
+- artifact attestation;
 - Homebrew formula update path.
 
 Recommended platforms:
@@ -73,9 +83,46 @@ Recommended platforms:
 - `linux-amd64`;
 - `linux-arm64`.
 
+## Mandatory command contract
+
+Every installable tool must implement:
+
+```bash
+<tool> --version
+<tool> doctor
+<tool> self-test
+<tool> emit-evidence
+```
+
+`prophet` must expose façade commands for every product surface:
+
+```bash
+prophet doctor
+prophet version
+prophet sourceos install
+prophet sourceos carry list
+prophet sourceos carry validate
+prophet holmes analyze
+prophet model route
+prophet guardrail test
+prophet agent registry list
+```
+
+## Distribution modes
+
+Use the right distribution mode for the artifact:
+
+- Homebrew formula: CLI tools and lightweight local service launchers.
+- Homebrew cask: later GUI apps such as 221B workspace, if produced.
+- Container image: server workloads and platform services.
+- Nix package/dev shell: SourceOS and SociOS reproducible environments.
+- BootReleaseSet/ReleaseSet: OS installer, recovery, rollback, and system plane artifacts.
+
+Homebrew installs orchestrators and clients. It does not distribute raw OS images or unmanaged model artifacts.
+
 ## SourceOS rule
 
-SourceOS installables may install clients, launchers, profile managers, cache managers, and evidence collectors.
+SourceOS installables may install clients, launchers, profile managers, cache managers, installer orchestrators, and evidence collectors.
 
 SourceOS installables must not install mutable model lifecycle authority.
 
@@ -83,18 +130,22 @@ SourceOS installables must not install mutable model lifecycle authority.
 
 SociOS lab installables may install lab CLIs and environment launchers.
 
-Heavy training frameworks, model artifacts, datasets, and adapters should be pulled through signed, reproducible lab environment definitions rather than bundled into Homebrew formulae.
+Heavy training frameworks, datasets, and adapters should be pulled through signed, reproducible lab environment definitions rather than bundled into Homebrew formulae.
 
 ## Release chain
 
 ```text
 source commit
-  -> CI build
-  -> tests
-  -> signed release artifacts
+  -> CI test
+  -> build matrix
   -> checksums
+  -> SBOM
+  -> artifact attestation
+  -> signed GitHub Release
   -> Homebrew formula update
+  -> brew audit/test
   -> brew install
+  -> doctor/self-test
   -> local evidence receipt
 ```
 
@@ -105,7 +156,10 @@ A product surface is not release-ready until:
 1. it has a binary or executable CLI entrypoint;
 2. it publishes a GitHub Release artifact;
 3. it has checksums;
-4. it has a Homebrew formula;
-5. `brew install` works on Apple Silicon;
-6. `--version` and `doctor` commands work;
-7. it emits enough local evidence to identify version, build source, and service references.
+4. it has an SBOM;
+5. it has an artifact attestation;
+6. it has a Homebrew formula;
+7. `brew install` works on Apple Silicon;
+8. `--version`, `doctor`, `self-test`, and `emit-evidence` commands work;
+9. it emits enough local evidence to identify version, build source, platform, policy, and service references;
+10. it has a rollback or previous-version recovery path when it modifies device state.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,0 +1,111 @@
+# Distribution and Installability
+
+## Position
+
+Functional model surfaces must be installable products, not only source repositories.
+
+Every product-facing surface should produce a versioned command-line or service binary, publish release artifacts, and expose a Homebrew-installable formula through the SocioProphet tap.
+
+## Artifact policy
+
+Do not commit compiled binaries into the repository as long-lived `build/` contents.
+
+Build outputs should be produced by CI and attached to GitHub Releases or release artifact storage. Repositories may contain fixtures, examples, and generated manifests, but product binaries should be release artifacts.
+
+## Install surfaces
+
+The public install target should be a Homebrew tap:
+
+```bash
+brew tap SocioProphet/prophet
+brew install holmes
+brew install sourceos-ai
+brew install prophet-cli
+```
+
+The initial tap repository should be:
+
+```text
+SocioProphet/homebrew-prophet
+```
+
+This provides the short tap name:
+
+```text
+SocioProphet/prophet
+```
+
+## Product formulae
+
+Initial formulae should include:
+
+- `holmes`: Holmes language intelligence CLI and local service controller.
+- `sourceos-ai`: SourceOS AI carry client and local service launcher.
+- `prophet-cli`: Prophet platform operator CLI.
+- `model-router`: model/service routing client and policy simulator.
+- `guardrail-fabric`: guardrail test and local policy evaluation CLI.
+- `agent-registry`: agent spec and identity registry client.
+
+Lab formulae should be lightweight. They should install scaffolding and reproducible environment launchers, not large unmanaged model artifacts.
+
+- `nlplab`
+- `translationlab`
+- `embeddinglab`
+- `timeserieslab`
+- `graphlab`
+
+## Binary strategy
+
+Each product repo should provide:
+
+- `cmd/<name>/` or equivalent CLI entrypoint;
+- `Makefile` target `build`;
+- `Makefile` target `test`;
+- `Makefile` target `dist`;
+- GitHub Actions release workflow;
+- release checksum generation;
+- Homebrew formula update path.
+
+Recommended platforms:
+
+- `darwin-arm64` for Apple Silicon;
+- `darwin-amd64` where needed;
+- `linux-amd64`;
+- `linux-arm64`.
+
+## SourceOS rule
+
+SourceOS installables may install clients, launchers, profile managers, cache managers, and evidence collectors.
+
+SourceOS installables must not install mutable model lifecycle authority.
+
+## Lab rule
+
+SociOS lab installables may install lab CLIs and environment launchers.
+
+Heavy training frameworks, model artifacts, datasets, and adapters should be pulled through signed, reproducible lab environment definitions rather than bundled into Homebrew formulae.
+
+## Release chain
+
+```text
+source commit
+  -> CI build
+  -> tests
+  -> signed release artifacts
+  -> checksums
+  -> Homebrew formula update
+  -> brew install
+  -> local evidence receipt
+```
+
+## Definition of done
+
+A product surface is not release-ready until:
+
+1. it has a binary or executable CLI entrypoint;
+2. it publishes a GitHub Release artifact;
+3. it has checksums;
+4. it has a Homebrew formula;
+5. `brew install` works on Apple Silicon;
+6. `--version` and `doctor` commands work;
+7. it emits enough local evidence to identify version, build source, and service references.

--- a/docs/HOLMES.md
+++ b/docs/HOLMES.md
@@ -1,0 +1,159 @@
+# Holmes
+
+Holmes is the SocioProphet language intelligence fabric.
+
+Holmes exists to outgrow assistant-grade discovery. It is not a chatbot wrapper and it is not a domain-specific NLP repo. It is the governed language layer above search, retrieval, linguistic analysis, semantic graph conversion, agents, tools, evals, and evidence-first discovery.
+
+## Product line
+
+- **Holmes**: language intelligence fabric.
+- **Sherlock Search**: discovery, retrieval, evidence search, and investigation engine.
+- **221B**: casefile and workspace surface.
+- **Mycroft**: model routing, policy intelligence, and strategic selection.
+- **Moriarty Bench**: adversarial eval and red-team harness.
+- **Irene Shield**: privacy, masking, identity-sensitive redaction, and sensitive-context handling.
+- **The Canon**: curated evidence corpus, provenance records, accepted facts, and source trust.
+- **Deduction Engine**: synthesis, contradiction detection, claim extraction, fallacy analysis, and reasoning workflows.
+
+## Positioning
+
+Watson-style systems answer. Holmes investigates.
+
+Holmes should combine classical NLP, neural NLP, retrieval, semantic graphs, foundation language services, guardrails, evals, agent tools, and governed evidence workflows.
+
+## Layer stack
+
+### Layer 0: Ingestion
+
+- file loaders;
+- PDF and document extraction;
+- HTML extraction;
+- OCR handoff;
+- transcript handoff;
+- table extraction;
+- metadata extraction;
+- language detection.
+
+### Layer 1: Linguistic primitives
+
+- tokenization;
+- sentence detection;
+- lemmatization;
+- stemming;
+- part-of-speech tagging;
+- morphology;
+- dependency parsing;
+- constituency parsing;
+- named entity recognition;
+- numeric and temporal normalization.
+
+### Layer 2: Rule and table techniques
+
+- regex and phrase matching;
+- gazetteers;
+- spaCy matchers and entity rulers;
+- taxonomy matchers;
+- table parsers;
+- header detection;
+- schema extraction;
+- rule-based relation extraction.
+
+### Layer 3: Classical ML NLP
+
+- scikit-learn classifiers;
+- clustering;
+- topic models;
+- keyword extraction;
+- sentiment baselines;
+- calibration;
+- explainable baseline models.
+
+### Layer 4: Neural NLP
+
+- PyTorch pipelines;
+- transformer encoders and decoders;
+- token classification;
+- sequence classification;
+- span extraction;
+- relation extraction;
+- embeddings;
+- rerankers;
+- multilingual encoders.
+
+### Layer 5: Foundation language services
+
+- extraction;
+- summarization;
+- reasoning;
+- generation;
+- translation;
+- text-to-SQL;
+- RAG answering;
+- long-context analysis;
+- tool planning.
+
+### Layer 6: Retrieval and knowledge
+
+- sparse search;
+- dense search;
+- hybrid retrieval;
+- rerank;
+- vector stores;
+- GraphBrain integration;
+- semantic-serdes integration;
+- ontogenesis integration;
+- Sherlock Search integration;
+- Slash Topics integration.
+
+### Layer 7: Guardrails and governance
+
+- PII and sensitive data detection;
+- prompt-injection checks;
+- source provenance checks;
+- citation requirements;
+- policy gates;
+- eval gates;
+- factsheets;
+- promotion records.
+
+### Layer 8: Agent and tool orchestration
+
+- tool contracts;
+- agent identity;
+- session state;
+- memory state;
+- MCP/A2A integration;
+- execution traces;
+- workspace policy;
+- model routing.
+
+## Method families
+
+Internal methods should be TriTRPC-first. Gateway routes can exist for browser and external clients.
+
+Recommended method families:
+
+- `language.primitive.v1/Analyze`
+- `language.entity.v1/Extract`
+- `language.relation.v1/Extract`
+- `language.classify.v1/Classify`
+- `language.embed.v1/Embed`
+- `language.rerank.v1/Rerank`
+- `language.translate.v1/Translate`
+- `language.summarize.v1/Summarize`
+- `language.rag.v1/Answer`
+- `language.graph.v1/ToSemanticGraph`
+- `language.govern.v1/Evaluate`
+
+## Repo placement
+
+- `SocioProphet/functional-model-surfaces`: normative surface and object standards.
+- `SocioProphet/holmes`: dedicated Holmes product repo once created.
+- `SocioProphet/sherlock-search`: Watson Discovery competitor surface and investigation engine.
+- `SocioProphet/prophet-platform`: runtime implementation once contracts are valid.
+- `SociOS-Linux/nlplab`: local NLP lab execution and pipeline experiments once created.
+- `SourceOS-Linux/sourceos-model-carry`: carry refs and on-device launch integration.
+
+## Non-goals
+
+Holmes must not be a loose model zoo, a single monolithic model, or a domain-specific application. It is a governed language intelligence fabric that domains consume through adapters, policies, evals, and evidence.


### PR DESCRIPTION
Closed as superseded by #3.

Reason: this PR was stale/diverged from current `main` and included an older README replacement that would overwrite newer maturity/schema content. The useful docs were replayed cleanly in #3 and merged.