### PR TITLE
Add functional model surface architecture and distribution docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,118 @@
+# Functional Model Surfaces Architecture
+
+## Core thesis
+
+Functional model surfaces are reusable capability families. They are not domain repositories and they are not application-specific feature folders.
+
+A functional surface is the stable contract around a capability such as speech, OCR, image, video, translation, embeddings, rerank, guardrails, tools, or agents. Domains bind to those surfaces through adapters, datasets, policies, eval gates, and promotion records.
+
+## Layer model
+
+1. Functional foundation surface
+2. Task adapter
+3. Domain adapter
+4. Organization, project, or user policy
+5. Eval gate
+6. Signed promotion
+7. Runtime deployment
+8. SourceOS carry reference
+
+## Object graph
+
+```text
+FunctionalModelSurface
+  -> FoundationModelRef
+  -> TaskAdapter
+  -> DomainAdapter
+  -> DatasetArtifact
+  -> TrainingRun
+  -> ModelArtifact
+  -> AdapterArtifact
+  -> EvalRun
+  -> GuardrailPolicy
+  -> ToolContract
+  -> KnowledgeBaseRef
+  -> AgentSpec
+  -> AgentIdentity
+  -> RuntimeDeployment
+  -> ModelRouterPolicy
+  -> PromotionRecord
+  -> SourceOSCarryRef
+```
+
+## Authority split
+
+### SocioProphet
+
+SocioProphet owns governed platform capability:
+
+- standards and contracts;
+- service catalog entries;
+- runtime service manifests;
+- TriTRPC and gateway bindings;
+- evaluation gates;
+- evidence and promotion records;
+- guardrail and routing policy;
+- model, adapter, dataset, tool, knowledge-base, and agent registries.
+
+### SociOS Linux
+
+SociOS Linux owns local lab execution:
+
+- training and tuning experiments;
+- datasets and local corpora;
+- model and adapter candidates;
+- workstation and accelerator integration;
+- reproducible lab shells;
+- local smoke tests and eval fixtures.
+
+### SourceOS
+
+SourceOS owns secure carriage and launch:
+
+- clients;
+- launch profiles;
+- signed service references;
+- ReleaseSet and BootReleaseSet wiring;
+- cache policy;
+- evidence collectors;
+- offline-safe fallback references.
+
+SourceOS must not become the authority for mutable model updates.
+
+## Promotion chain
+
+```text
+lab experiment
+  -> dataset evidence
+  -> training or tuning evidence
+  -> artifact digest
+  -> eval gate
+  -> guardrail policy
+  -> deployment mode
+  -> routing policy
+  -> signed promotion
+  -> SourceOS carry reference
+```
+
+## Runtime binding
+
+Internal platform services should be TriTRPC-first. HTTP gateway routes may exist for browser and external access, but the normative internal service contract should remain typed, signed, and evidence-aware.
+
+Recommended method families:
+
+- `modality.speech.v1/*`
+- `modality.ocr.v1/*`
+- `modality.image.v1/*`
+- `modality.video.v1/*`
+- `modality.translation.v1/*`
+- `modality.embedding.v1/*`
+- `guardrail.fabric.v1/*`
+- `model.router.v1/*`
+- `agent.registry.v1/*`
+
+## Non-goals
+
+This repository does not store model binaries, mutable model update channels, domain datasets, or runtime service implementations.
+
+Runtime implementation belongs in `SocioProphet/prophet-platform` or in explicitly designated service repos. Lab execution belongs in SociOS Linux lab repos. SourceOS carriage contracts belong in SourceOS standards and carry surfaces.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,0 +1,122 @@
+# Distribution and Installability
+
+## Position
+
+Functional model surfaces must become installable, testable product surfaces. A repo is not product-grade until it can produce validated artifacts, a command or service entrypoint, and evidence proving what was built and installed.
+
+## Golden path
+
+```bash
+brew tap SocioProphet/prophet
+brew install prophet-cli
+prophet doctor
+prophet devtools profile list
+prophet sourceos carry list
+prophet holmes analyze ./document.txt
+```
+
+Specialized binaries may exist, but every product path should also be available through `prophet`.
+
+## Core formulae
+
+Initial Homebrew targets:
+
+- `prophet-cli`
+- `sourceos-ai`
+- `holmes`
+- `sourceos-devtools`
+- `sourceos-installer`
+- `model-router`
+- `guardrail-fabric`
+- `agent-registry`
+
+Lab formulae are lightweight launchers and environment selectors, not bundles of large artifacts:
+
+- `nlplab`
+- `translationlab`
+- `embeddinglab`
+- `timeserieslab`
+- `graphlab`
+- `imagelab`
+- `speechlab`
+- `ocrlab`
+- `videolab`
+
+## SourceOS Developer Tools
+
+`sourceos-devtools` is the Linux/AI-native developer tools layer for SourceOS and SocioProphet.
+
+It installs a governed profile manager and lab launcher. It must not blindly install every heavy dependency, dataset, or model artifact.
+
+Initial profile families:
+
+- `core`
+- `build`
+- `containers`
+- `k8s`
+- `ai-core`
+- `labs`
+- `security`
+
+## Mandatory command contract
+
+Every installable tool should implement:
+
+```bash
+<tool> --version
+<tool> doctor
+<tool> self-test
+<tool> emit-evidence
+```
+
+`prophet` should expose facade commands for every product surface:
+
+```bash
+prophet doctor
+prophet version
+prophet devtools profile list
+prophet lab list
+prophet sourceos install
+prophet sourceos carry validate
+prophet holmes analyze
+prophet model route
+prophet guardrail test
+prophet agent registry list
+```
+
+## Release chain
+
+```text
+source commit
+  -> CI test
+  -> build matrix
+  -> checksums
+  -> SBOM
+  -> artifact attestation
+  -> signed GitHub Release
+  -> Homebrew formula update
+  -> brew audit/test
+  -> local evidence receipt
+```
+
+## Artifact policy
+
+Do not commit long-lived compiled binaries into source repositories. Build outputs belong in CI artifacts, signed releases, or release storage.
+
+## SourceOS rule
+
+SourceOS may carry clients, launchers, profile managers, cache managers, installer orchestrators, signed service references, and evidence collectors.
+
+SourceOS must not carry mutable model lifecycle authority.
+
+## Definition of done
+
+A product surface is not release-ready until:
+
+1. it has a command or service entrypoint;
+2. validation passes in CI;
+3. release artifacts are checksummed;
+4. SBOM/provenance exists;
+5. evidence output exists;
+6. install path is documented;
+7. rollback or recovery behavior is described where state changes occur.

--- a/docs/HOLMES.md
+++ b/docs/HOLMES.md
@@ -1,0 +1,66 @@
+# Holmes
+
+Holmes is the SocioProphet language intelligence fabric.
+
+Holmes exists to outgrow assistant-grade discovery. It is not a chatbot wrapper and it is not a domain-specific NLP repo. It is the governed language layer above search, retrieval, linguistic analysis, semantic graph conversion, agents, tools, evals, and evidence-first discovery.
+
+## Product line
+
+- **Holmes**: language intelligence fabric.
+- **Sherlock Search**: discovery, retrieval, evidence search, and investigation engine.
+- **221B**: casefile and workspace surface.
+- **Mycroft**: model routing, policy intelligence, and strategic selection.
+- **Moriarty Bench**: adversarial eval and red-team harness.
+- **Irene Shield**: privacy, masking, identity-sensitive redaction, and sensitive-context handling.
+- **The Canon**: curated evidence corpus, provenance records, accepted facts, and source trust.
+- **Deduction Engine**: synthesis, contradiction detection, claim extraction, fallacy analysis, and reasoning workflows.
+
+## Positioning
+
+Watson-style systems answer. Holmes investigates.
+
+Holmes combines classical NLP, neural NLP, retrieval, semantic graphs, foundation language services, guardrails, evals, agent tools, and governed evidence workflows.
+
+## Layer stack
+
+1. ingestion;
+2. linguistic primitives;
+3. rule and table techniques;
+4. classical ML NLP;
+5. neural NLP;
+6. foundation language services;
+7. retrieval and knowledge;
+8. guardrails and governance;
+9. agent and tool orchestration.
+
+## Method families
+
+Internal methods should be TriTRPC-first. Gateway routes can exist for browser and external clients.
+
+Recommended method families:
+
+- `language.primitive.v1/Analyze`
+- `language.entity.v1/Extract`
+- `language.relation.v1/Extract`
+- `language.classify.v1/Classify`
+- `language.embed.v1/Embed`
+- `language.rerank.v1/Rerank`
+- `language.translate.v1/Translate`
+- `language.summarize.v1/Summarize`
+- `language.rag.v1/Answer`
+- `language.graph.v1/ToSemanticGraph`
+- `language.govern.v1/Evaluate`
+
+## Repo placement
+
+- `SocioProphet/functional-model-surfaces`: normative surface and object standards.
+- `SocioProphet/holmes`: Holmes product repo and CLI/service surface.
+- `SocioProphet/sherlock-search`: discovery, retrieval, evidence search, and investigation engine.
+- `SocioProphet/prophet-core-query`: governed shared query contracts.
+- `SocioProphet/prophet-platform`: runtime implementation once contracts are valid.
+- `SociOS-Linux/nlplab`: local NLP lab execution and pipeline experiments.
+- `SourceOS-Linux/sourceos-model-carry`: carry refs and on-device launch integration.
+
+## Non-goals
+
+Holmes must not become a loose model zoo, a single monolithic model, or a domain-specific application. It is a governed language intelligence fabric that domains consume through adapters, policies, evals, and evidence.


### PR DESCRIPTION
## Summary

Replays the useful documentation from stale PR #1 onto current `main` without overwriting the newer README and schema/maturity work.

Adds:

- `docs/ARCHITECTURE.md`
- `docs/DISTRIBUTION.md`
- `docs/HOLMES.md`

## Why this replaces #1

PR #1 is stale/diverged and includes an older README replacement that would overwrite newer `main` content. This replacement keeps the newer README and adds only the missing docs.

## Scope

Documentation only. No schemas, runtime code, generated artifacts, binaries, model artifacts, or datasets.

## Validation

No repo workflow is triggered by this docs-only branch at creation time. Review scope is file placement and standards consistency.
