### PR TITLE
Add Prophet Intelligence Foundry contract spine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,13 @@ validate: lint examples maturity negatives
 lint:
 	python3 -m json.tool schemas/repo-maturity.schema.json >/dev/null
 	python3 -m json.tool schemas/functional-service.schema.json >/dev/null
+	python3 -m json.tool schemas/prophet-foundry-contract-spine.schema.json >/dev/null
 	python3 -m json.tool examples/functional-service.example.json >/dev/null
+	python3 -m json.tool examples/prophet-foundry-contract-spine.example.json >/dev/null
 
 examples:
 	python3 tools/validate_json.py schemas/functional-service.schema.json examples/functional-service.example.json
+	python3 tools/validate_json.py schemas/prophet-foundry-contract-spine.schema.json examples/prophet-foundry-contract-spine.example.json
 
 maturity:
 	python3 tools/validate_maturity.py schemas/repo-maturity.schema.json repo.maturity.yaml

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The SocioProphet roadmap calls for AI/NLP collaboration, a community model zoo, 
 | CLI | `SocioProphet/prophet-cli` | User/operator command surface that consumes these contracts. |
 | Governance | `SocioProphet/model-governance-ledger`, `SocioProphet/guardrail-fabric`, `SocioProphet/model-router`, `SocioProphet/agent-registry` | Promotion, policy, routing, guardrails, and agent authority. |
 | OS carry | `SourceOS-Linux/sourceos-model-carry` | Carry-only references for SourceOS; no mutable model updates in OS images. |
+| Local runtime | `SourceOS-Linux/agent-machine` | Machine-local runtime probing, inference provider lifecycle, model residency, cache-aware scheduling facts, AgentPod placement, and receipts. |
 | Labs | `SociOS-Linux/*lab` | Modality-specific workspaces that emit functional service manifests. |
 | Workspace governance | `SocioProphet/sociosphere`, `SocioProphet/workspace-inventory` | Estate registration, validation, and maturity telemetry. |
 
@@ -25,6 +26,7 @@ The SocioProphet roadmap calls for AI/NLP collaboration, a community model zoo, 
 3. SourceOS carries service references, launch profiles, cache policy, and refusal gates; it does not carry mutable model updates.
 4. Every functional service must be auditable through datasets, adapters, evals, guardrails, routing policy, and ledger evidence.
 5. Every active repo must emit a maturity record consumable by Sociosphere/workspace governance.
+6. Prophet Intelligence Foundry contracts are lifecycle contracts. They do not make this repository a training runtime, model-weight store, or workspace controller.
 
 ## Contracts in this repo
 
@@ -32,7 +34,10 @@ The SocioProphet roadmap calls for AI/NLP collaboration, a community model zoo, 
 | --- | --- | --- |
 | Repository maturity | `schemas/repo-maturity.schema.json` | Standard scorecard for repo readiness. |
 | Functional service | `schemas/functional-service.schema.json` | Manifest emitted by labs and consumed by runtime/governance. |
+| Prophet Foundry contract spine | `schemas/prophet-foundry-contract-spine.schema.json` | v0.1 contract spine reserving canonical names, authority repos, minimum fields, promotion flow, and must-not-own boundaries for Prophet model/data/training/eval/release/runtime contracts. |
 | Example maturity record | `examples/repo.maturity.example.yaml` | Copyable starting point for other repos. |
+| Example functional service | `examples/functional-service.example.json` | Copyable service manifest fixture. |
+| Example Foundry spine | `examples/prophet-foundry-contract-spine.example.json` | Copyable v0.1 Foundry contract fixture. |
 | This repo's maturity record | `repo.maturity.yaml` | Current maturity state for this standards repo. |
 
 ## Maturity gates
@@ -54,6 +59,6 @@ make validate
 
 ## First vertical slice
 
-`functional-model-surfaces -> lab repo -> model-governance-ledger -> model-router -> guardrail-fabric -> agent-registry -> sourceos-model-carry -> sociosphere`
+`functional-model-surfaces -> lab repo -> model-governance-ledger -> model-router -> guardrail-fabric -> agent-registry -> sourceos-model-carry -> agent-machine -> agentplane -> sociosphere`
 
-The proof condition is simple: a lab emits a functional service manifest, governance validates it, SourceOS carries the approved reference, and Sociosphere records maturity/evidence for the whole path.
+The proof condition is simple: a lab emits a functional service manifest, governance validates it, SourceOS carries the approved reference, Agent Machine proves runtime placement, AgentPlane captures run evidence, and Sociosphere records maturity/evidence for the whole path.

--- a/docs/prophet-intelligence-foundry-v0.1.md
+++ b/docs/prophet-intelligence-foundry-v0.1.md
@@ -1,0 +1,102 @@
+# Prophet Intelligence Foundry v0.1
+
+Status: Draft contract spine
+
+## Purpose
+
+The Prophet Intelligence Foundry is the contract-first program plane for turning model work into auditable, governable, SourceOS-carryable intelligence services.
+
+It is not a runtime router, workspace controller, chat UI, or model-weight repository. It defines how model families, data manifests, training runs, post-training runs, reward models, evals, safety reports, interpretability reports, release decisions, runtime reasoning plans, tool contracts, capability grants, run capsules, and Agent Machine receipts connect across the SocioProphet and SourceOS estate.
+
+## Boundary statement
+
+- `functional-model-surfaces` defines the contracts.
+- `model-governance-ledger` records evidence, factsheets, evals, release decisions, rollback records, and compliance state.
+- `model-router` selects governed model/service routes at runtime.
+- `guardrail-fabric` applies safety and runtime governance around models, agents, tools, RAG packages, and knowledge bases.
+- `sourceos-model-carry` carries approved service references, launch profiles, cache policy, fallback references, ReleaseSet and BootReleaseSet bindings, and evidence collectors.
+- `agent-machine` owns machine-local runtime probing, inference providers, model residency, cache-aware scheduling facts, AgentPod envelopes, and AgentMachineReceipt evidence.
+- `agentplane` owns validated execution, run capsules, replay, and evidence capture.
+- `sociosphere` owns workspace state and materialization. It does not own cognitive routing or model release governance.
+
+## v0.1 contract families
+
+The v0.1 schema intentionally starts as a contract spine rather than full final schemas for every object. The goal is to reserve canonical names, repository authority, minimum fields, and must-not-own boundaries before runtime code grows around unstable assumptions.
+
+Required families:
+
+- `ModelSpec`
+- `ModelFamilySpec`
+- `AdapterSpec`
+- `DatasetSpec`
+- `DataManifest`
+- `TrainingRun`
+- `PostTrainingRun`
+- `RewardModelSpec`
+- `EvalSuite`
+- `EvalReport`
+- `SafetyReport`
+- `InterpretabilityReport`
+- `ModelReleaseDecision`
+- `ReasoningRuntimePlan`
+- `ModelRoutingDecision`
+- `MemoryRoutingPlan`
+- `ToolContract`
+- `CapabilityGrant`
+- `WorkspaceLease`
+- `RunCapsule`
+- `AgentMachineReceipt`
+- `ModelResidency`
+- `InferenceProvider`
+- `ContextBundle`
+- `VerifierQuorum`
+
+## Promotion law
+
+A lab candidate is not a product service until it passes the foundry path:
+
+```text
+lab manifest
+→ data manifest
+→ eval report
+→ safety / guardrail review
+→ model governance ledger release decision
+→ model-router admission
+→ sourceos-model-carry approved reference
+→ agent-machine runtime placement evidence
+→ agentplane run capsule
+→ SourceOS/operator surface readout
+```
+
+## Runtime law
+
+Runtime work must preserve this split:
+
+```text
+Model Mesh routes.
+Policy Fabric authorizes.
+AgentPlane executes.
+Agent Machine places and proves local runtime facts.
+Sociosphere materializes workspace state.
+TurtleTerm, BearBrowser, AgentTerm, sourceosctl, and SourceOS Shell expose operator surfaces.
+model-governance-ledger records durable release and evidence state.
+```
+
+## What v0.1 deliberately does not do
+
+- It does not ship model weights.
+- It does not define a training framework implementation.
+- It does not grant authority to any agent or tool.
+- It does not create SourceOS boot or carry state.
+- It does not replace existing `functional-service.v1` manifests.
+- It does not make `smart-tree` or any MCP tool trusted by default.
+
+## Acceptance criteria
+
+The initial contract spine is valid when:
+
+1. `schemas/prophet-foundry-contract-spine.schema.json` is valid JSON Schema.
+2. `examples/prophet-foundry-contract-spine.example.json` validates against it.
+3. `make validate` checks the new schema and example.
+4. The README advertises the contract family without implying runtime readiness.
+5. Downstream repos can reference the reserved contract family names without inventing competing names.

--- a/examples/prophet-foundry-contract-spine.example.json
+++ b/examples/prophet-foundry-contract-spine.example.json
@@ -1,0 +1,171 @@
+{
+  "schemaVersion": "prophet-foundry-contract-spine.v0.1",
+  "foundry": {
+    "id": "prophet-intelligence-foundry",
+    "name": "Prophet Intelligence Foundry",
+    "status": "proposed",
+    "boundaryNotes": "Contract-first program for Prophet model data, training, post-training, RL, eval, release, and runtime promotion. It does not replace model-router, AgentPlane, Policy Fabric, Sociosphere, or SourceOS carry layers."
+  },
+  "contractFamilies": [
+    {
+      "name": "ModelSpec",
+      "status": "stub",
+      "owningPlane": "foundry",
+      "canonicalRepository": "SocioProphet/functional-model-surfaces",
+      "purpose": "Describe a Prophet model or compatible external model candidate before governance, routing, or SourceOS carry.",
+      "minimumFields": ["modelId", "family", "role", "architectureClass", "modalities", "governanceStatus"],
+      "mustNotOwn": ["runtime placement", "workspace mutation", "release approval"]
+    },
+    {
+      "name": "DataManifest",
+      "status": "stub",
+      "owningPlane": "foundry",
+      "canonicalRepository": "SocioProphet/functional-model-surfaces",
+      "purpose": "Record dataset/source/provenance/privacy/decontamination metadata for model training, eval, or synthetic data generation.",
+      "minimumFields": ["manifestId", "dataClass", "sources", "licenseClass", "privacyClass", "provenanceHash"],
+      "mustNotOwn": ["private raw data", "runtime memory writes", "release approval"]
+    },
+    {
+      "name": "TrainingRun",
+      "status": "stub",
+      "owningPlane": "foundry",
+      "canonicalRepository": "SocioProphet/functional-model-surfaces",
+      "purpose": "Describe pretraining, continued-pretraining, SFT, preference optimization, RL, distillation, adapter tuning, or eval-only runs.",
+      "minimumFields": ["runId", "runClass", "baseModelRef", "dataManifestRefs", "objective", "status", "evidenceRef"],
+      "mustNotOwn": ["model promotion", "SourceOS carry", "runtime route selection"]
+    },
+    {
+      "name": "EvalReport",
+      "status": "stub",
+      "owningPlane": "governance",
+      "canonicalRepository": "SocioProphet/functional-model-surfaces",
+      "purpose": "Summarize capability, reliability, autonomy, safety, cost, and regression evidence for a model/service candidate.",
+      "minimumFields": ["reportId", "modelRef", "suiteVersion", "capabilityScores", "safetyScores", "releaseRecommendation"],
+      "mustNotOwn": ["training data", "workspace execution", "local runtime placement"]
+    },
+    {
+      "name": "ModelReleaseDecision",
+      "status": "stub",
+      "owningPlane": "governance",
+      "canonicalRepository": "SocioProphet/functional-model-surfaces",
+      "purpose": "Record release-stage approval, block, remediation, revocation, rollback, and required evidence references.",
+      "minimumFields": ["decisionId", "modelRef", "stage", "decision", "requiredEvidenceRefs"],
+      "mustNotOwn": ["model training", "inference serving", "workspace mutation"]
+    },
+    {
+      "name": "ReasoningRuntimePlan",
+      "status": "stub",
+      "owningPlane": "routing",
+      "canonicalRepository": "SocioProphet/functional-model-surfaces",
+      "purpose": "Describe test-time compute mode, model graph, verifier policy, memory routing, tool policy, and computation budgets for a task.",
+      "minimumFields": ["planId", "taskClass", "reasoningMode", "modelGraph", "budgets", "verifierPolicy"],
+      "mustNotOwn": ["policy grant issuance", "workspace lock state", "model training"]
+    },
+    {
+      "name": "CapabilityGrant",
+      "status": "stub",
+      "owningPlane": "safety",
+      "canonicalRepository": "SocioProphet/functional-model-surfaces",
+      "purpose": "Represent bounded authority for an agent, task, tools, side effects, paths, policy hash, and expiry.",
+      "minimumFields": ["grantId", "subjectAgent", "humanAnchor", "allowedTools", "allowedSideEffects", "expiresAt"],
+      "mustNotOwn": ["model choice", "training run state", "repository inventory"]
+    },
+    {
+      "name": "RunCapsule",
+      "status": "stub",
+      "owningPlane": "agent-execution",
+      "canonicalRepository": "SocioProphet/functional-model-surfaces",
+      "purpose": "Represent replayable agent execution evidence across prompt digests, model refs, retrieved context, tool calls, workspace lease, receipts, diffs, tests, and final artifacts.",
+      "minimumFields": ["capsuleId", "taskId", "modelRefs", "toolCallRefs", "evidenceRefs"],
+      "mustNotOwn": ["workspace materialization", "policy authorship", "model release approval"]
+    },
+    {
+      "name": "AgentMachineReceipt",
+      "status": "stub",
+      "owningPlane": "runtime",
+      "canonicalRepository": "SocioProphet/functional-model-surfaces",
+      "sourceosProjectionRepository": "SourceOS-Linux/sourceos-spec",
+      "purpose": "Represent machine-local runtime evidence for probing, placement, execution, model load/unload, cache reuse, and policy-mediated side effects.",
+      "minimumFields": ["receiptId", "machineRef", "receiptClass", "placementFacts", "evidenceHash"],
+      "mustNotOwn": ["AgentPlane orchestration", "Policy Fabric authorization", "model-router selection"]
+    },
+    {
+      "name": "ToolContract",
+      "status": "stub",
+      "owningPlane": "safety",
+      "canonicalRepository": "SocioProphet/functional-model-surfaces",
+      "purpose": "Describe tool schemas, side effects, required capabilities, rollback strategy, and audit level before tool execution is admitted.",
+      "minimumFields": ["toolId", "sideEffectClass", "requiredCapabilities", "auditLevel"],
+      "mustNotOwn": ["tool implementation", "workspace state", "model weights"]
+    }
+  ],
+  "requiredRepositories": [
+    {
+      "repository": "SocioProphet/functional-model-surfaces",
+      "role": "contract spine",
+      "boundary": "Defines model, dataset, eval, release, routing, guardrail, tool, agent, and promotion contracts."
+    },
+    {
+      "repository": "SocioProphet/model-governance-ledger",
+      "role": "evidence ledger",
+      "boundary": "Records dataset, run, eval, safety, promotion, rollback, factsheet, and compliance evidence."
+    },
+    {
+      "repository": "SocioProphet/model-router",
+      "role": "route selector",
+      "boundary": "Selects governed model/service routes; does not train, release, or mutate workspaces."
+    },
+    {
+      "repository": "SocioProphet/guardrail-fabric",
+      "role": "safety fabric",
+      "boundary": "Provides guardrail policy around models, agents, tools, RAG packages, knowledge bases, and runtime deployment."
+    },
+    {
+      "repository": "SourceOS-Linux/sourceos-model-carry",
+      "role": "on-device service carry",
+      "boundary": "Carries approved signed model/service references, launch profiles, cache policy, and fallback references; no mutable model updates in OS images."
+    },
+    {
+      "repository": "SourceOS-Linux/agent-machine",
+      "role": "machine-local runtime substrate",
+      "boundary": "Owns runtime probing, inference provider lifecycle, model residency, cache-aware scheduling facts, AgentPod envelopes, and AgentMachineReceipt evidence."
+    },
+    {
+      "repository": "SocioProphet/agentplane",
+      "role": "agent execution plane",
+      "boundary": "Owns run lifecycle, validation, evidence capture, replay, and execution receipts."
+    }
+  ],
+  "promotionFlow": [
+    {
+      "step": "lab emits candidate functional service manifest",
+      "authority": "SocioProphet/functional-model-surfaces",
+      "requiredEvidence": ["FunctionalService", "DataManifest", "EvalReport"]
+    },
+    {
+      "step": "governance records evidence and release decision",
+      "authority": "SocioProphet/model-governance-ledger",
+      "requiredEvidence": ["EvalReport", "SafetyReport", "ModelReleaseDecision"]
+    },
+    {
+      "step": "routing admits a governed model/service route",
+      "authority": "SocioProphet/model-router",
+      "requiredEvidence": ["ModelRoutingDecision", "ReasoningRuntimePlan", "VerifierQuorum"]
+    },
+    {
+      "step": "SourceOS carries approved references only",
+      "authority": "SourceOS-Linux/sourceos-model-carry",
+      "requiredEvidence": ["ModelReleaseDecision", "SourceOS carry profile", "cache policy"]
+    },
+    {
+      "step": "Agent Machine emits runtime placement and execution receipts",
+      "authority": "SourceOS-Linux/agent-machine",
+      "requiredEvidence": ["AgentMachineReceipt", "ModelResidency", "InferenceProvider"]
+    },
+    {
+      "step": "AgentPlane binds receipts into replayable run capsules",
+      "authority": "SocioProphet/agentplane",
+      "requiredEvidence": ["RunCapsule", "CapabilityGrant", "ToolContract"]
+    }
+  ]
+}

--- a/schemas/prophet-foundry-contract-spine.schema.json
+++ b/schemas/prophet-foundry-contract-spine.schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/functional-model-surfaces/prophet-foundry-contract-spine.v0.1.json",
+  "title": "Prophet Intelligence Foundry Contract Spine",
+  "description": "Contract-first spine for Prophet model family, data, training, evaluation, release, reasoning runtime, and governed execution integration.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "foundry",
+    "contractFamilies",
+    "requiredRepositories",
+    "promotionFlow"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "prophet-foundry-contract-spine.v0.1"
+    },
+    "foundry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "status", "boundaryNotes"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9_.-]+$" },
+        "name": { "type": "string" },
+        "status": { "type": "string", "enum": ["draft", "proposed", "active", "deprecated"] },
+        "boundaryNotes": { "type": "string" }
+      }
+    },
+    "contractFamilies": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/contractFamily" }
+    },
+    "requiredRepositories": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/repositoryBinding" }
+    },
+    "promotionFlow": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/promotionStep" }
+    }
+  },
+  "$defs": {
+    "repositoryRef": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+    },
+    "contractFamily": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "status", "owningPlane", "canonicalRepository", "purpose", "minimumFields"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "enum": [
+            "ModelSpec",
+            "ModelFamilySpec",
+            "AdapterSpec",
+            "DatasetSpec",
+            "DataManifest",
+            "TrainingRun",
+            "PostTrainingRun",
+            "RewardModelSpec",
+            "EvalSuite",
+            "EvalReport",
+            "SafetyReport",
+            "InterpretabilityReport",
+            "ModelReleaseDecision",
+            "ReasoningRuntimePlan",
+            "ModelRoutingDecision",
+            "MemoryRoutingPlan",
+            "ToolContract",
+            "CapabilityGrant",
+            "WorkspaceLease",
+            "RunCapsule",
+            "AgentMachineReceipt",
+            "ModelResidency",
+            "InferenceProvider",
+            "ContextBundle",
+            "VerifierQuorum"
+          ]
+        },
+        "status": { "type": "string", "enum": ["stub", "draft", "candidate", "approved", "deprecated"] },
+        "owningPlane": {
+          "type": "string",
+          "enum": ["foundry", "governance", "routing", "safety", "runtime", "agent-execution", "workspace", "sourceos-carry", "memory-retrieval"]
+        },
+        "canonicalRepository": { "$ref": "#/$defs/repositoryRef" },
+        "sourceosProjectionRepository": { "$ref": "#/$defs/repositoryRef" },
+        "purpose": { "type": "string" },
+        "minimumFields": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "mustNotOwn": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "repositoryBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "role", "boundary"],
+      "properties": {
+        "repository": { "$ref": "#/$defs/repositoryRef" },
+        "role": { "type": "string" },
+        "boundary": { "type": "string" }
+      }
+    },
+    "promotionStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["step", "authority", "requiredEvidence"],
+      "properties": {
+        "step": { "type": "string" },
+        "authority": { "$ref": "#/$defs/repositoryRef" },
+        "requiredEvidence": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `schemas/prophet-foundry-contract-spine.schema.json` as a v0.1 contract spine for Prophet Intelligence Foundry work.
- Adds `examples/prophet-foundry-contract-spine.example.json` as a machine-checkable fixture.
- Adds `docs/prophet-intelligence-foundry-v0.1.md` defining the Foundry boundary, required contract families, promotion law, and runtime law.
- Updates `Makefile` so `make validate` checks the new schema and fixture.
- Updates README to advertise the Foundry spine without implying runtime readiness.

## Validation

- Authored the schema and example as JSON and validated them locally with Python/jsonschema before pushing.
- Compared branch against `main`: 5 commits ahead, 0 behind.
- Changed files are limited to README, Makefile, docs, schema, and example fixture.

## Boundary notes

This PR intentionally does not add runtime code, model weights, mutable adapters, training data, or SourceOS image state. It reserves contract-family names and authority boundaries so downstream runtime work does not invent competing semantics.