### PR TITLE
Add TrustOps Fabric contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,21 @@ lint:
 	python3 -m json.tool schemas/repo-maturity.schema.json >/dev/null
 	python3 -m json.tool schemas/functional-service.schema.json >/dev/null
 	python3 -m json.tool schemas/prophet-foundry-contract-spine.schema.json >/dev/null
+	python3 -m json.tool schemas/trustops-receipt.schema.json >/dev/null
+	python3 -m json.tool schemas/trust-gate-policy.schema.json >/dev/null
+	python3 -m json.tool schemas/dataset-risk-manifest.schema.json >/dev/null
 	python3 -m json.tool examples/functional-service.example.json >/dev/null
 	python3 -m json.tool examples/prophet-foundry-contract-spine.example.json >/dev/null
+	python3 -m json.tool examples/trustops-receipt.art-smoke.example.json >/dev/null
+	python3 -m json.tool examples/trust-gate-policy.example.json >/dev/null
+	python3 -m json.tool examples/dataset-risk-manifest.example.json >/dev/null
 
 examples:
 	python3 tools/validate_json.py schemas/functional-service.schema.json examples/functional-service.example.json
 	python3 tools/validate_json.py schemas/prophet-foundry-contract-spine.schema.json examples/prophet-foundry-contract-spine.example.json
+	python3 tools/validate_json.py schemas/trustops-receipt.schema.json examples/trustops-receipt.art-smoke.example.json
+	python3 tools/validate_json.py schemas/trust-gate-policy.schema.json examples/trust-gate-policy.example.json
+	python3 tools/validate_json.py schemas/dataset-risk-manifest.schema.json examples/dataset-risk-manifest.example.json
 
 maturity:
 	python3 tools/validate_maturity.py schemas/repo-maturity.schema.json repo.maturity.yaml

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The SocioProphet roadmap calls for AI/NLP collaboration, a community model zoo, 
 4. Every functional service must be auditable through datasets, adapters, evals, guardrails, routing policy, and ledger evidence.
 5. Every active repo must emit a maturity record consumable by Sociosphere/workspace governance.
 6. Prophet Intelligence Foundry contracts are lifecycle contracts. They do not make this repository a training runtime, model-weight store, or workspace controller.
+7. TrustOps provider libraries are runner backends and regression oracles. SocioProphet owns the receipts, gates, policy interpretation, local-first execution semantics, and runtime enforcement loop.
 
 ## Contracts in this repo
 
@@ -35,10 +36,27 @@ The SocioProphet roadmap calls for AI/NLP collaboration, a community model zoo, 
 | Repository maturity | `schemas/repo-maturity.schema.json` | Standard scorecard for repo readiness. |
 | Functional service | `schemas/functional-service.schema.json` | Manifest emitted by labs and consumed by runtime/governance. |
 | Prophet Foundry contract spine | `schemas/prophet-foundry-contract-spine.schema.json` | v0.1 contract spine reserving canonical names, authority repos, minimum fields, promotion flow, and must-not-own boundaries for Prophet model/data/training/eval/release/runtime contracts. |
+| TrustOps receipt | `schemas/trustops-receipt.schema.json` | Evidence receipt for fairness, robustness, explanation, uncertainty, RAG, ranking, dataset, and agent-trust evaluations. |
+| Trust gate policy | `schemas/trust-gate-policy.schema.json` | Policy contract that converts TrustOps receipts into allow, warn, review, quarantine, block, rollback, or revocation decisions. |
+| Dataset risk manifest | `schemas/dataset-risk-manifest.schema.json` | Dataset contract for lineage, labels, protected/sensitive attributes, data boundary, consent, and risk controls. |
 | Example maturity record | `examples/repo.maturity.example.yaml` | Copyable starting point for other repos. |
 | Example functional service | `examples/functional-service.example.json` | Copyable service manifest fixture. |
 | Example Foundry spine | `examples/prophet-foundry-contract-spine.example.json` | Copyable v0.1 Foundry contract fixture. |
+| Example TrustOps receipt | `examples/trustops-receipt.art-smoke.example.json` | ART-first robustness receipt fixture for TrustOps runner integration. |
+| Example TrustOps gate policy | `examples/trust-gate-policy.example.json` | Platform-default gate policy fixture for receipt-to-action mapping. |
+| Example dataset risk manifest | `examples/dataset-risk-manifest.example.json` | Synthetic dataset risk fixture for fairness/privacy evaluation. |
 | This repo's maturity record | `repo.maturity.yaml` | Current maturity state for this standards repo. |
+
+## TrustOps Fabric
+
+TrustOps Fabric turns responsible-AI libraries into enforceable platform governance. AIF360, ART, AIX360, UQ-style libraries, and future providers are isolated runners. Core platform services consume normalized receipts and policies, not provider-specific Python objects.
+
+Start here:
+
+- `docs/TRUSTOPS_FABRIC.md`
+- `schemas/trustops-receipt.schema.json`
+- `schemas/trust-gate-policy.schema.json`
+- `schemas/dataset-risk-manifest.schema.json`
 
 ## Maturity gates
 
@@ -62,3 +80,9 @@ make validate
 `functional-model-surfaces -> lab repo -> model-governance-ledger -> model-router -> guardrail-fabric -> agent-registry -> sourceos-model-carry -> agent-machine -> agentplane -> sociosphere`
 
 The proof condition is simple: a lab emits a functional service manifest, governance validates it, SourceOS carries the approved reference, Agent Machine proves runtime placement, AgentPlane captures run evidence, and Sociosphere records maturity/evidence for the whole path.
+
+## TrustOps vertical slice
+
+`functional-model-surfaces -> prophet-platform trustops runner -> model-governance-ledger receipt -> guardrail-fabric policy action -> model-router route/fallback/block -> agent-registry authority effect -> SourceOS local/enterprise runner -> Sociosphere trust posture`
+
+The proof condition is also simple: a service emits a manifest, TrustOps runs an ART-first robustness profile, the ledger records the receipt, guardrails and routing consume the decision, agent authority is adjusted where required, and only signed/redacted evidence leaves local or enterprise data boundaries by default.

--- a/docs/TRUSTOPS_FABRIC.md
+++ b/docs/TRUSTOPS_FABRIC.md
@@ -1,0 +1,84 @@
+# TrustOps Fabric
+
+TrustOps Fabric is the SocioProphet control-plane pattern for turning responsible-AI toolkits into enforceable platform governance.
+
+The platform does not vendor a research toolkit as its architecture. AIF360, ART, AIX360, UQ360, and future providers are runner backends. SocioProphet owns the contracts, receipts, policy gates, local-first execution semantics, model-router controls, guardrail actions, ledger records, and agent-authority effects.
+
+## First-class contracts
+
+| Contract | Path | Purpose |
+| --- | --- | --- |
+| TrustOps receipt | `schemas/trustops-receipt.schema.json` | Canonical evidence receipt for fairness, robustness, explanation, uncertainty, RAG, ranking, dataset, and agent-trust evaluations. |
+| Trust gate policy | `schemas/trust-gate-policy.schema.json` | Converts receipts into allow, warn, review, quarantine, block, rollback, or revocation decisions. |
+| Dataset risk manifest | `schemas/dataset-risk-manifest.schema.json` | Declares lineage, label semantics, protected/sensitive attribute handling, data boundary, consent, and risk controls. |
+
+## Provider strategy
+
+Provider libraries are isolated runners, not core dependencies.
+
+| Provider | Role |
+| --- | --- |
+| `trustops-art-runner` | Adversarial robustness, privacy leakage, extraction, inference, poisoning, evasion, prompt/tool/memory attack probes. |
+| `trustops-aif360-runner` | Fairness metrics, subgroup scans, counterfactual fairness, ranking fairness, and mitigation comparison. |
+| `trustops-aix360-runner` | Explanation generation, explanation quality, local/global and direct/post-hoc explanation evidence. |
+| `trustops-uq-runner` | Uncertainty, calibration, abstention, fallback, and human-review signals. |
+| `socioprophet-trust-kernel` | Small deterministic in-house metric and policy evaluator used for core checks and regression comparisons. |
+
+## Control loop
+
+1. A lab, model, adapter, RAG package, tool, agent, or functional service emits a manifest.
+2. TrustOps selects provider runners from policy and data boundary.
+3. Runners execute locally, in CI, in SourceOS, or in enterprise-controlled infrastructure.
+4. Runners emit normalized TrustOps receipts.
+5. `model-governance-ledger` records immutable receipts and factsheet evidence.
+6. `guardrail-fabric` converts receipts into runtime controls.
+7. `model-router` routes, falls back, blocks, or escalates.
+8. `agent-registry` reduces, revokes, or restores tool grants, memory access, and runtime authority.
+9. Sociosphere/workspace governance records maturity and operational posture.
+
+## Non-negotiable invariants
+
+- Core platform services consume receipts, not provider-specific Python objects.
+- Raw regulated, personal, or customer-controlled data must not leave its boundary by default.
+- Promotion requires current receipts for every required TrustOps gate.
+- A failing robustness or privacy gate may quarantine or block deployment.
+- A failing fairness gate blocks high-risk promotion unless an explicit governed waiver exists.
+- High uncertainty must trigger fallback, abstention, or human review where policy requires it.
+- Agent authority must be tied to trust posture, not static registration alone.
+- Factsheets must be generated from evidence receipts, not manually maintained prose.
+
+## Initial vertical slice
+
+The first implementation lane is ART-first:
+
+1. Add `robustness` support through `trustops-receipt.v1`.
+2. Implement `trustops-art-runner` in `SocioProphet/prophet-platform`.
+3. Record receipts in `SocioProphet/model-governance-ledger`.
+4. Map receipt status to runtime controls in `SocioProphet/guardrail-fabric`.
+5. Apply agent-authority impact in `SocioProphet/agent-registry`.
+6. Expose a CLI/API path such as:
+
+```bash
+prophet trustops run --profile art-smoke --manifest examples/functional-service.example.json
+```
+
+## Build versus integrate
+
+Trusted-AI libraries are useful as backends and regression oracles. They should not own the SocioProphet architecture.
+
+Build ourselves:
+- Schemas and receipts.
+- Gate policy semantics.
+- Ledger integration.
+- Router and guardrail enforcement.
+- Agent authority controls.
+- SourceOS/local-first runner model.
+- Deterministic trust kernel for stable core metrics.
+
+Integrate selectively:
+- ART for adversarial robustness coverage.
+- AIF360 for fairness metric and mitigation breadth.
+- AIX360 for explanation algorithms and taxonomy.
+- UQ-style libraries for uncertainty methods where useful.
+
+The long-term goal is a sovereign TrustOps Fabric: measure, explain, record, enforce, route, revoke, rollback, and improve.

--- a/examples/dataset-risk-manifest.example.json
+++ b/examples/dataset-risk-manifest.example.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": "dataset-risk-manifest.v1",
+  "dataset": {
+    "id": "dataset-risk.demo-public-fixture",
+    "name": "Demo Public Fixture",
+    "ownerRepository": "SocioProphet/functional-model-surfaces",
+    "versionRef": "demo-v0.1",
+    "description": "Synthetic fixture used to validate TrustOps receipts without exporting raw sensitive data."
+  },
+  "lineage": {
+    "sourceRefs": [
+      "synthetic://fixtures/demo-public"
+    ],
+    "transformationRefs": [
+      "transform://none"
+    ],
+    "licenseOrTerms": "synthetic-fixture",
+    "collectionWindow": "not-applicable"
+  },
+  "labels": {
+    "labelColumns": [
+      "approved"
+    ],
+    "favorableOutcome": true,
+    "unfavorableOutcome": false,
+    "rankingOutcomeColumn": "rank_score"
+  },
+  "attributes": {
+    "protectedAttributes": [
+      {
+        "name": "demo_group",
+        "handling": "synthetic",
+        "privilegedValues": [
+          "A"
+        ],
+        "unprivilegedValues": [
+          "B"
+        ]
+      }
+    ],
+    "sensitiveAttributes": [],
+    "proxyRiskNotes": "Synthetic fixture only."
+  },
+  "dataBoundary": {
+    "classification": "synthetic",
+    "rawExportAllowed": false,
+    "consentRequired": false,
+    "retentionPolicyRef": "policy.synthetic-fixture-retention",
+    "deletionPolicyRef": "policy.synthetic-fixture-deletion"
+  },
+  "riskControls": {
+    "requiresFairnessEval": true,
+    "requiresPrivacyEval": true,
+    "requiresHumanReview": false,
+    "allowedEvalProfiles": [
+      "art-smoke",
+      "aif360-smoke"
+    ],
+    "mustNotUseFor": [
+      "production-decisioning"
+    ]
+  }
+}

--- a/examples/trust-gate-policy.example.json
+++ b/examples/trust-gate-policy.example.json
@@ -1,0 +1,79 @@
+{
+  "schemaVersion": "trust-gate-policy.v1",
+  "policyId": "trustgate.platform-default",
+  "scope": {
+    "appliesTo": [
+      "model",
+      "adapter",
+      "rag-package",
+      "agent",
+      "functional-service"
+    ],
+    "ownerRepositories": [
+      "SocioProphet/prophet-platform",
+      "SocioProphet/functional-model-surfaces"
+    ],
+    "runtimeProfiles": [
+      "ci",
+      "platform",
+      "sourceos-runner"
+    ]
+  },
+  "gates": [
+    {
+      "gateId": "robustness",
+      "receiptTypes": [
+        "robustness"
+      ],
+      "requiredStatus": "pass",
+      "minimumFreshnessDays": 30,
+      "requiredMetricStatuses": [
+        "pass"
+      ],
+      "onPass": "allow",
+      "onWarn": "require-review",
+      "onFail": "quarantine",
+      "waiverAllowed": false
+    },
+    {
+      "gateId": "fairness",
+      "receiptTypes": [
+        "fairness",
+        "ranking-fairness"
+      ],
+      "requiredStatus": "review-allowed",
+      "minimumFreshnessDays": 30,
+      "requiredMetricStatuses": [
+        "pass",
+        "warn"
+      ],
+      "onPass": "allow",
+      "onWarn": "require-review",
+      "onFail": "block",
+      "waiverAllowed": true
+    }
+  ],
+  "defaultAction": "require-review",
+  "owners": [
+    "SocioProphet/platform-governance"
+  ],
+  "standardsCrosswalk": [
+    {
+      "standard": "NIST AI RMF",
+      "controlRefs": [
+        "GOVERN",
+        "MAP",
+        "MEASURE",
+        "MANAGE"
+      ]
+    },
+    {
+      "standard": "ISO/IEC 42001",
+      "controlRefs": [
+        "AI management system",
+        "risk treatment",
+        "monitoring"
+      ]
+    }
+  ]
+}

--- a/examples/trustops-receipt.art-smoke.example.json
+++ b/examples/trustops-receipt.art-smoke.example.json
@@ -1,0 +1,108 @@
+{
+  "schemaVersion": "trustops-receipt.v1",
+  "receiptId": "trustops.art-smoke.functional-service.demo-v0.1",
+  "receiptType": "robustness",
+  "subject": {
+    "kind": "functional-service",
+    "id": "demo-classifier",
+    "ownerRepository": "SocioProphet/prophet-platform",
+    "versionRef": "demo-v0.1",
+    "functionalServiceRef": "functional-service.demo-classifier"
+  },
+  "runner": {
+    "id": "trustops-art-runner",
+    "provider": "art",
+    "version": "1.20.x",
+    "executionMode": "ci",
+    "containerRef": "ghcr.io/socioprophet/trustops-art-runner:0.1.0",
+    "codeDigest": "sha256:example"
+  },
+  "inputs": {
+    "manifests": [
+      "examples/functional-service.example.json"
+    ],
+    "datasetRefs": [
+      "dataset-risk.demo-public-fixture"
+    ],
+    "modelRefs": [
+      "model.demo-classifier"
+    ],
+    "policyRefs": [
+      "trustgate.platform-default"
+    ],
+    "protectedAttributeRefs": [],
+    "dataBoundary": "synthetic",
+    "rawDataExported": false
+  },
+  "evaluation": {
+    "profile": "art-smoke",
+    "threatClasses": [
+      "evasion",
+      "inference",
+      "extraction"
+    ],
+    "metricFamilies": [
+      "robustness",
+      "privacy-leakage"
+    ],
+    "metrics": [
+      {
+        "name": "evasion_attack_success_rate",
+        "value": 0.08,
+        "threshold": 0.1,
+        "direction": "at-or-below",
+        "status": "pass",
+        "sliceRef": "all"
+      },
+      {
+        "name": "membership_inference_risk",
+        "value": "low",
+        "threshold": "medium",
+        "direction": "at-or-below",
+        "status": "pass",
+        "sliceRef": "all"
+      }
+    ]
+  },
+  "policy": {
+    "gateRef": "trustgate.platform-default.robustness",
+    "decision": "allow",
+    "reviewer": "automation"
+  },
+  "result": {
+    "status": "pass",
+    "summary": "ART smoke profile passed. No blocking adversarial or privacy leakage signal was observed in the synthetic fixture.",
+    "residualRisk": "low",
+    "recommendedMitigations": [
+      "Run full robustness profile before production promotion."
+    ]
+  },
+  "evidence": {
+    "artifactRefs": [
+      "artifact://trustops/art-smoke/demo-classifier/report.json"
+    ],
+    "redactionPolicy": "metrics-only",
+    "factsheetRefs": [
+      "factsheet.demo-classifier"
+    ]
+  },
+  "actions": [
+    {
+      "target": "model-governance-ledger",
+      "action": "record",
+      "details": "Store robustness receipt and promotion evidence."
+    },
+    {
+      "target": "guardrail-fabric",
+      "action": "allow",
+      "details": "No additional runtime guardrail required for synthetic smoke profile."
+    }
+  ],
+  "provenance": {
+    "createdAt": "2026-05-04T00:00:00Z",
+    "createdBy": "trustops-ci",
+    "sourceCommit": "0000000000000000000000000000000000000000",
+    "receiptDigest": "sha256:example",
+    "signatureRef": "sigstore://example"
+  }
+}

--- a/schemas/dataset-risk-manifest.schema.json
+++ b/schemas/dataset-risk-manifest.schema.json
@@ -1,0 +1,244 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/functional-model-surfaces/dataset-risk-manifest.v1.json",
+  "title": "SocioProphet Dataset Risk Manifest",
+  "description": "Dataset contract for fairness, privacy, lineage, protected-attribute, consent, and lawful-use evaluation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "dataset",
+    "lineage",
+    "labels",
+    "attributes",
+    "dataBoundary",
+    "riskControls"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "dataset-risk-manifest.v1"
+    },
+    "dataset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "ownerRepository",
+        "versionRef"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "ownerRepository": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+        },
+        "versionRef": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sourceRefs",
+        "transformationRefs",
+        "licenseOrTerms"
+      ],
+      "properties": {
+        "sourceRefs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transformationRefs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "licenseOrTerms": {
+          "type": "string"
+        },
+        "collectionWindow": {
+          "type": "string"
+        }
+      }
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "labelColumns"
+      ],
+      "properties": {
+        "labelColumns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "favorableOutcome": {
+          "type": [
+            "string",
+            "number",
+            "boolean"
+          ]
+        },
+        "unfavorableOutcome": {
+          "type": [
+            "string",
+            "number",
+            "boolean"
+          ]
+        },
+        "rankingOutcomeColumn": {
+          "type": "string"
+        }
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "protectedAttributes",
+        "sensitiveAttributes"
+      ],
+      "properties": {
+        "protectedAttributes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "handling"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "handling": {
+                "type": "string",
+                "enum": [
+                  "direct",
+                  "proxy-risk",
+                  "withheld",
+                  "synthetic",
+                  "not-collected"
+                ]
+              },
+              "privilegedValues": {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "string",
+                    "number",
+                    "boolean"
+                  ]
+                }
+              },
+              "unprivilegedValues": {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "string",
+                    "number",
+                    "boolean"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "sensitiveAttributes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "proxyRiskNotes": {
+          "type": "string"
+        }
+      }
+    },
+    "dataBoundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "classification",
+        "rawExportAllowed",
+        "consentRequired"
+      ],
+      "properties": {
+        "classification": {
+          "type": "string",
+          "enum": [
+            "synthetic",
+            "public",
+            "internal",
+            "customer-controlled",
+            "personal-consented",
+            "regulated"
+          ]
+        },
+        "rawExportAllowed": {
+          "type": "boolean",
+          "const": false
+        },
+        "consentRequired": {
+          "type": "boolean"
+        },
+        "retentionPolicyRef": {
+          "type": "string"
+        },
+        "deletionPolicyRef": {
+          "type": "string"
+        }
+      }
+    },
+    "riskControls": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requiresFairnessEval",
+        "requiresPrivacyEval",
+        "requiresHumanReview"
+      ],
+      "properties": {
+        "requiresFairnessEval": {
+          "type": "boolean"
+        },
+        "requiresPrivacyEval": {
+          "type": "boolean"
+        },
+        "requiresHumanReview": {
+          "type": "boolean"
+        },
+        "allowedEvalProfiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mustNotUseFor": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/trust-gate-policy.schema.json
+++ b/schemas/trust-gate-policy.schema.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/functional-model-surfaces/trust-gate-policy.v1.json",
+  "title": "SocioProphet Trust Gate Policy",
+  "description": "Policy contract that converts TrustOps receipts into promotion, routing, guardrail, rollback, and agent-authority actions.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "policyId",
+    "scope",
+    "gates",
+    "defaultAction",
+    "owners"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "trust-gate-policy.v1"
+    },
+    "policyId": {
+      "type": "string",
+      "pattern": "^trustgate\\.[a-z0-9][a-z0-9_.:-]+$"
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "appliesTo"
+      ],
+      "properties": {
+        "appliesTo": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "model",
+              "adapter",
+              "dataset",
+              "rag-package",
+              "agent",
+              "tool",
+              "functional-service",
+              "route-policy"
+            ]
+          }
+        },
+        "ownerRepositories": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+          }
+        },
+        "runtimeProfiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "gates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "gateId",
+          "receiptTypes",
+          "requiredStatus",
+          "onPass",
+          "onWarn",
+          "onFail"
+        ],
+        "properties": {
+          "gateId": {
+            "type": "string"
+          },
+          "receiptTypes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "fairness",
+                "robustness",
+                "explanation",
+                "uncertainty",
+                "ranking-fairness",
+                "rag-trust",
+                "agent-trust",
+                "dataset-risk"
+              ]
+            }
+          },
+          "requiredStatus": {
+            "type": "string",
+            "enum": [
+              "pass",
+              "warn-allowed",
+              "review-allowed"
+            ]
+          },
+          "minimumFreshnessDays": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "requiredMetricStatuses": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "onPass": {
+            "type": "string",
+            "enum": [
+              "allow",
+              "record",
+              "route-primary"
+            ]
+          },
+          "onWarn": {
+            "type": "string",
+            "enum": [
+              "warn",
+              "require-review",
+              "route-fallback",
+              "quarantine"
+            ]
+          },
+          "onFail": {
+            "type": "string",
+            "enum": [
+              "block",
+              "quarantine",
+              "rollback",
+              "revoke"
+            ]
+          },
+          "waiverAllowed": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "defaultAction": {
+      "type": "string",
+      "enum": [
+        "block",
+        "require-review",
+        "warn"
+      ]
+    },
+    "owners": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "standardsCrosswalk": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "standard",
+          "controlRefs"
+        ],
+        "properties": {
+          "standard": {
+            "type": "string"
+          },
+          "controlRefs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/trustops-receipt.schema.json
+++ b/schemas/trustops-receipt.schema.json
@@ -1,0 +1,459 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/functional-model-surfaces/trustops-receipt.v1.json",
+  "title": "SocioProphet TrustOps Receipt",
+  "description": "Canonical evidence receipt for fairness, robustness, explanation, uncertainty, RAG, ranking, and agent-trust evaluations.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "receiptId",
+    "receiptType",
+    "subject",
+    "runner",
+    "inputs",
+    "evaluation",
+    "policy",
+    "result",
+    "evidence",
+    "actions",
+    "provenance"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "trustops-receipt.v1"
+    },
+    "receiptId": {
+      "type": "string",
+      "pattern": "^trustops\\.[a-z0-9][a-z0-9_.:-]+$"
+    },
+    "receiptType": {
+      "type": "string",
+      "enum": [
+        "fairness",
+        "robustness",
+        "explanation",
+        "uncertainty",
+        "ranking-fairness",
+        "rag-trust",
+        "agent-trust",
+        "dataset-risk"
+      ]
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "id",
+        "ownerRepository",
+        "versionRef"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "model",
+            "adapter",
+            "dataset",
+            "rag-package",
+            "agent",
+            "tool",
+            "functional-service",
+            "route-policy"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "ownerRepository": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+        },
+        "versionRef": {
+          "type": "string"
+        },
+        "functionalServiceRef": {
+          "type": "string"
+        }
+      }
+    },
+    "runner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "provider",
+        "version",
+        "executionMode"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string",
+          "enum": [
+            "socioprophet-trust-kernel",
+            "aif360",
+            "art",
+            "aix360",
+            "uq360",
+            "custom"
+          ]
+        },
+        "version": {
+          "type": "string"
+        },
+        "executionMode": {
+          "type": "string",
+          "enum": [
+            "local",
+            "ci",
+            "platform",
+            "enterprise-runner",
+            "sourceos-runner"
+          ]
+        },
+        "containerRef": {
+          "type": "string"
+        },
+        "codeDigest": {
+          "type": "string"
+        }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "manifests",
+        "dataBoundary",
+        "rawDataExported"
+      ],
+      "properties": {
+        "manifests": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "datasetRefs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "modelRefs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policyRefs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "protectedAttributeRefs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "dataBoundary": {
+          "type": "string",
+          "enum": [
+            "synthetic",
+            "public",
+            "internal",
+            "customer-controlled",
+            "personal-consented",
+            "regulated"
+          ]
+        },
+        "rawDataExported": {
+          "type": "boolean",
+          "const": false
+        }
+      }
+    },
+    "evaluation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "profile",
+        "metrics"
+      ],
+      "properties": {
+        "profile": {
+          "type": "string"
+        },
+        "threatClasses": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "evasion",
+              "poisoning",
+              "extraction",
+              "inference",
+              "prompt-injection",
+              "tool-abuse",
+              "rag-leakage",
+              "memory-leakage"
+            ]
+          }
+        },
+        "metricFamilies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "group-fairness",
+              "individual-fairness",
+              "ranking-fairness",
+              "counterfactual",
+              "subgroup-scan",
+              "calibration",
+              "uncertainty",
+              "explanation-quality",
+              "robustness",
+              "privacy-leakage"
+            ]
+          }
+        },
+        "metrics": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "value",
+              "threshold",
+              "status"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": [
+                  "number",
+                  "string",
+                  "boolean"
+                ]
+              },
+              "threshold": {
+                "type": [
+                  "number",
+                  "string",
+                  "boolean"
+                ]
+              },
+              "direction": {
+                "type": "string",
+                "enum": [
+                  "at-or-above",
+                  "at-or-below",
+                  "equals",
+                  "informational"
+                ]
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "pass",
+                  "warn",
+                  "fail",
+                  "info"
+                ]
+              },
+              "sliceRef": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "gateRef",
+        "decision"
+      ],
+      "properties": {
+        "gateRef": {
+          "type": "string"
+        },
+        "decision": {
+          "type": "string",
+          "enum": [
+            "allow",
+            "warn",
+            "require-review",
+            "quarantine",
+            "block",
+            "rollback",
+            "revoke"
+          ]
+        },
+        "waiverRef": {
+          "type": "string"
+        },
+        "reviewer": {
+          "type": "string"
+        },
+        "expiresAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "summary"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "pass",
+            "warn",
+            "fail",
+            "error"
+          ]
+        },
+        "summary": {
+          "type": "string"
+        },
+        "residualRisk": {
+          "type": "string",
+          "enum": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ]
+        },
+        "recommendedMitigations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifactRefs",
+        "redactionPolicy"
+      ],
+      "properties": {
+        "artifactRefs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "redactionPolicy": {
+          "type": "string",
+          "enum": [
+            "none",
+            "metrics-only",
+            "redacted-artifacts",
+            "local-only"
+          ]
+        },
+        "factsheetRefs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "target",
+          "action"
+        ],
+        "properties": {
+          "target": {
+            "type": "string",
+            "enum": [
+              "model-router",
+              "guardrail-fabric",
+              "agent-registry",
+              "model-governance-ledger",
+              "sourceos-carry",
+              "human-review"
+            ]
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "record",
+              "allow",
+              "warn",
+              "route-fallback",
+              "require-review",
+              "quarantine",
+              "block",
+              "rollback",
+              "revoke-authority",
+              "disable-reference"
+            ]
+          },
+          "details": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "createdAt",
+        "createdBy",
+        "sourceCommit",
+        "receiptDigest"
+      ],
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "createdBy": {
+          "type": "string"
+        },
+        "sourceCommit": {
+          "type": "string"
+        },
+        "receiptDigest": {
+          "type": "string"
+        },
+        "signatureRef": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the first TrustOps Fabric contract layer for turning responsible-AI provider libraries into SocioProphet-native governance receipts and policy gates.

This is intentionally standards-first and provider-neutral. AIF360, ART, AIX360, UQ-style libraries, and future providers are treated as isolated runner backends and regression oracles. SocioProphet owns the contracts, receipts, policy interpretation, local-first execution semantics, runtime enforcement, and agent-authority effects.

## Added

- `schemas/trustops-receipt.schema.json`
  - Canonical receipt for fairness, robustness, explanation, uncertainty, RAG, ranking, dataset, and agent-trust evaluations.
- `schemas/trust-gate-policy.schema.json`
  - Maps TrustOps receipts into allow, warn, review, quarantine, block, rollback, and revocation decisions.
- `schemas/dataset-risk-manifest.schema.json`
  - Captures dataset lineage, label semantics, protected/sensitive attributes, data boundary, consent, and risk controls.
- Example fixtures for each new schema.
- `docs/TRUSTOPS_FABRIC.md`
  - Explains the build-vs-integrate strategy and ART-first vertical slice.
- README contract inventory and doctrine updates.
- Makefile validation wiring for all new JSON schemas/examples.

## First implementation lane

ART-first robustness gate:

1. Implement `trustops-art-runner` in `SocioProphet/prophet-platform`.
2. Emit `trustops-receipt.v1` robustness receipts.
3. Store receipts in `SocioProphet/model-governance-ledger`.
4. Map results to runtime controls in `SocioProphet/guardrail-fabric`.
5. Apply authority impacts in `SocioProphet/agent-registry`.

## Validation

The existing repo validator uses Draft 2020-12 JSON Schema. The Makefile now validates all new schemas and fixtures via `make validate`.