### PR TITLE
docs: v0.2 breaking-change policy for functional-model-surfaces schemas

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -111,6 +111,12 @@ Recommended method families:
 - `model.router.v1/*`
 - `agent.registry.v1/*`
 
+## v0.2 breaking-change policy
+
+See [`docs/v0.2-breaking-change-policy.md`](v0.2-breaking-change-policy.md) for the
+per-schema breaking-change rules, version-bump procedure, and consuming-repo coordination
+checklist.
+
 ## Non-goals
 
 This repository does not store model binaries, mutable model update channels, domain datasets, or runtime service implementations.

--- a/docs/v0.2-breaking-change-policy.md
+++ b/docs/v0.2-breaking-change-policy.md
@@ -1,0 +1,119 @@
+# Functional Model Surfaces v0.2 Breaking-Change Policy
+
+All schemas in this repository are at `v0.1`. This document defines the breaking-change
+policy for the first version bump to `v0.2`.
+
+---
+
+## Scope
+
+This policy covers:
+
+| Schema | Version | Consumed by |
+|--------|---------|-------------|
+| `functional-service.schema.json` | v0.1 | `prophet-mesh` agent-choir spec, `model-router` routing policy, `agent-registry` service catalog |
+| `trust-gate-policy.schema.json` | v0.1 | `guardrail-fabric` policy-as-code pipeline, `model-router` gate evaluation |
+| `trustops-receipt.schema.json` | v0.1 | `agentplane` dry-run receipt projection, `model-governance-ledger` evidence records |
+| `prophet-foundry-contract-spine.schema.json` | v0.1 | `prophet-platform` foundry contract validators |
+| `dataset-risk-manifest.schema.json` | v0.1 | `model-governance-ledger` dataset risk evidence |
+| `repo-maturity.schema.json` | v0.1 | `repo.maturity.yaml` across all SocioProphet repos, CI maturity-gate checks |
+
+---
+
+## What constitutes a breaking change
+
+### `functional-service.schema.json`
+
+A breaking change is any of:
+
+- Adding a new required field to the root schema or to `service`, `function`, `model`,
+  `inputs`, `outputs`, `evals`, `governance`, or `sourceosCarry` sub-objects
+- Removing or renaming any required field
+- Changing the allowed type or enum values of `schemaVersion`, `function.type`,
+  `governance.approvalRequired`, or any `sourceosCarry` field
+- Changing the `sourceosCarry` structure — `model-router` and SourceOS carry pipeline
+  consume this to determine what ref may be promoted
+
+### `trust-gate-policy.schema.json`
+
+A breaking change is any of:
+
+- Adding required fields to the root (`schemaVersion`, `policyId`, `scope`, `gates`,
+  `defaultAction`, `owners` are required today)
+- Changing `gates[].action` or `defaultAction` enum values — these drive guardrail-fabric
+  `controlling_outcome` logic
+- Changing `scope` structure — scope is matched against the consuming model-router's
+  task/privacy context
+
+### `trustops-receipt.schema.json`
+
+A breaking change is any of:
+
+- Changing fields referenced by `agentplane` dry-run receipt projection contract
+  (`prophet-mesh-agentplane-adapter.v0.1.json`)
+- Changing fields that appear in `model-governance-ledger` evidence records
+- Any change to the receipt's `content_sha256` structure or its computation method
+
+### `prophet-foundry-contract-spine.schema.json`
+
+A breaking change is any of:
+
+- Removing or changing required fields consumed by `prophet-platform`
+  foundry-contract validators
+
+### `dataset-risk-manifest.schema.json`
+
+A breaking change is any of:
+
+- Changing required fields or their types in ways that invalidate existing
+  `model-governance-ledger` risk evidence records
+
+### `repo-maturity.schema.json`
+
+A breaking change is any of:
+
+- Changing required fields or enum values for `maturity_level`, `gates`, or `status`
+  fields — all SocioProphet repo `repo.maturity.yaml` files are validated against this
+- Removing a maturity tier that existing repos are pinned to
+
+---
+
+## What is NOT a breaking change
+
+- Adding optional fields not in the `required` array
+- Adding new maturity tiers above the current maximum
+- Adding optional metadata or label fields to any schema
+- Updating `description` strings without changing field semantics
+- Adding new optional enum values where downstream consumers are required to handle
+  unknown values gracefully
+
+---
+
+## Version-bump procedure
+
+1. Create a new schema file at `v0.2` alongside the v0.1 file (never overwrite in place)
+2. Open coordinated PRs in all consuming repos before merging the v0.2 schema:
+   - `prophet-mesh`: update `specs/agent-choir.yaml`, `specs/model-router-interface.yaml`,
+     `specs/repo-state.yaml` to reference new schema version
+   - `model-router`: update any schema version pins in routing policy validators
+   - `guardrail-fabric`: update `trust-gate-policy` consumers if that schema changes
+   - `agentplane`: update adapter contract if `trustops-receipt` changes
+   - `model-governance-ledger`: update evidence record schemas
+   - `prophet-platform`: update foundry-contract validators
+3. Do not delete or modify any v0.1 schema file until all consumers confirm migration
+4. A `content_sha256` mismatch between two repos referencing the same schema path must be
+   flagged explicitly — never silently resolved by preferring one value
+
+---
+
+## Current state
+
+No schema has reached the v0.2 gate. Proceed with v0.2 only after:
+
+- A concrete field-level diff is filed as a schema change request in this repo
+- Coordinated PR readiness is confirmed in all consuming repos listed above
+- The v0.1 gate (`make validate`) passes in all consuming repos on the current schema
+
+---
+
+*Cross-reference: [`ARCHITECTURE.md`](ARCHITECTURE.md), [`TRUSTOPS_FABRIC.md`](TRUSTOPS_FABRIC.md)*


### PR DESCRIPTION
## Summary

- Adds `docs/v0.2-breaking-change-policy.md` defining per-schema breaking-change rules for all six schemas in this repo
- Covers `functional-service`, `trust-gate-policy`, `trustops-receipt`, `prophet-foundry-contract-spine`, `dataset-risk-manifest`, and `repo-maturity`
- Documents consuming repos (prophet-mesh, model-router, guardrail-fabric, agentplane, model-governance-ledger, prophet-platform), breaking vs non-breaking change rules, version-bump procedure, and current gate state
- Links from `ARCHITECTURE.md`

## Test plan

- [ ] `make validate` passes
- [ ] Doc renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)