### PR TITLE
chore(ci): harden supply chain — pin actions to SHA + least-privilege permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,15 +6,17 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
Supply-chain + least-privilege hardening (opened by a keeper pass — **for your review, not auto-merged**).

- **Pin actions to full commit SHA** (version comment retained) — floating `@vN` tags are a supply-chain injection vector.
- **Add least-privilege `permissions: contents: read`** where absent.
- **Add `.github/dependabot.yml`** (github-actions, weekly) to keep pins current.

Changed: validate.yml +perms, dependabot.yml (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)